### PR TITLE
Fix response smoothing factor not editable in GUI

### DIFF
--- a/pynot/response.py
+++ b/pynot/response.py
@@ -836,7 +836,9 @@ def task_response(options, database, status, log=None, verbose=True, app=None, o
                 log.write("Starting Graphical User Interface...")
                 try:
                     response = response_gui.run_gui(ext1d_output, response_output,
-                                                    order=3, smoothing=0.02, app=app)
+                                                    order=3,
+                                                    smoothing=options['response']['smoothing'],
+                                                    app=app)
                     log.write(" [OUTPUT] - Saving response function: %s" % response_output, prefix='')
                 except:
                     log.error("Unexpected error in response GUI: %r" % sys.exc_info()[0])

--- a/pynot/response_gui.py
+++ b/pynot/response_gui.py
@@ -104,7 +104,7 @@ class ResponseGUI(QtWidgets.QMainWindow):
         self.order_edit.returnPressed.connect(self.fit_response)
 
         self.smooth_edit = QtWidgets.QLineEdit("%.3f" % smoothing)
-        self.smooth_edit.setValidator(QtGui.QDoubleValidator())
+        # self.smooth_edit.setValidator(QtGui.QDoubleValidator())
         self.smooth_edit.returnPressed.connect(self.fit_response)
 
         self.fit_btn = QtWidgets.QPushButton("Fit Response")
@@ -500,7 +500,12 @@ class ResponseGUI(QtWidgets.QMainWindow):
             return
         wl = self.spectrum.wl
         order = int(self.order_edit.text())
-        smoothing = float(self.smooth_edit.text())
+        try:
+            smoothing = float(self.smooth_edit.text())
+        except Exception:
+            warn_msg = f"Invalid smoothing factor. It must be a numeral, not: {self.smooth_edit.text()}"
+            WarningDialog(self, "Invalid Smoothing Factor!", warn_msg)
+            return
         mask = self.mask
         # resp_fit = Chebyshev.fit(self.wl_bins[mask], self.resp_bins[mask], order, domain=[wl.min(), wl.max()])
         resp_fit = UnivariateSpline(self.wl_bins[mask], self.resp_bins[mask], k=order, s=smoothing)


### PR DESCRIPTION
Inherit the value from the options sheet. There seems to be a bug in the float validator for the input field in the GUI. I've added a manual check instead to ensure proper numeric values. This fixes #26 